### PR TITLE
[metastore-lib][s]: Add lfs server variable

### DIFF
--- a/lib/Metadata.js
+++ b/lib/Metadata.js
@@ -26,8 +26,10 @@ export default class Metadata{
       const config = {
         defaultAuthor: user, 
         token,
-        org: process.env.ORGANISATION_REPO
+        org: process.env.ORGANISATION_REPO,
+        lfsServerUrl: process.env.GIFTLESS_SERVER
       }
+
       const storage =  metastore.createMetastore('github', config)
 
       const response = await  storage.create({
@@ -58,7 +60,8 @@ export default class Metadata{
     const config = {
       defaultAuthor: user, 
       token,
-      org: process.env.ORGANISATION_REPO
+      org: process.env.ORGANISATION_REPO,
+      lfsServerUrl: process.env.GIFTLESS_SERVER
     }
     const storage =  metastore.createMetastore('github', config)
 


### PR DESCRIPTION
This pull fixes the lfs file creation issue when saving metadata to github 