### PR TITLE
[search][s]: Add message when search shows no dataset

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -68,6 +68,11 @@ export default function Home({ datasets }) {
           {dataState.map((value, i) => {
             return <Card props={value} key={i} />;
           })}
+          {(() => {
+            if (!dataState.length) {
+              return <p><strong>No results found for this search query.</strong></p>
+            }
+          })()}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR fixes #107, taking care of the last acceptance criterion:

> When the search matches no dataset, the text `No results found for this search query.` is displayed in the main section of the page as shown below.