### PR TITLE
Fix datapackage breaking bug

### DIFF
--- a/lib/Metastore.js
+++ b/lib/Metastore.js
@@ -26,7 +26,6 @@ export default class Metastore {
         const [catalogs, desCatalogs] = await processMultipleRepos(repos)
         resolve(desCatalogs)
       } catch (error) {
-        console.log(error)
         reject([])
       }
     })
@@ -39,10 +38,9 @@ export default class Metastore {
           query: SINGLE_REPOSITORY,
           variables: { name },
         })
-        const repo = processSingleRepo(response.repository)
+        const repo = await processSingleRepo(response.repository)
         resolve(repo)
       } catch (error) {
-        console.log(error)
         reject([])
       }
     })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,34 +1,28 @@
-
+import axios from 'axios'
 /* eslint-disable max-len */
 export const processMultipleRepos = async (repos) => {
-  return new Promise((resolve, reject) => {
-    try {
-      let catalogs = []
-      let desCatalogs = []
-      const repoNames = Object.keys(repos)
-      const repoLen = repoNames.length - 1
-      repoNames.forEach((repoName, i) => {
-        const repo = repos[repoName]
-        const datapackage = processRepo(repo)
-        catalogs[repo['name']] = datapackage
-        desCatalogs.push(datapackage)
-        if (i == repoLen) {
-          resolve([catalogs, desCatalogs])
-        }
-      })
-    } catch (error) {
-      console.log(error)
-      reject(error)
+  let catalogs = []
+  let desCatalogs = []
+  const repoNames = Object.keys(repos)
+  const repoLen = repoNames.length - 1
+  for (let i = 0; i < repoNames.length; i++) {
+    const repo = repos[repoNames[i]]
+    const datapackage = await processRepo(repo)
+    catalogs[repo['name']] = datapackage
+    desCatalogs.push(datapackage)
+    if (i == repoLen) {
+      return [catalogs, desCatalogs]
     }
-  })
+
+  }
 }
 
-export const processSingleRepo = (repo) => {
-  return processRepo(repo)
+export const processSingleRepo = async (repo) => {
+  return await processRepo(repo)
 }
 
 
-export const processRepo = (repo) => {
+export const processRepo = async (repo) => {
   try {
     const entries = repo.object.entries
     let _tempEntries = entries.filter((entry) => {
@@ -40,8 +34,7 @@ export const processRepo = (repo) => {
       let data = { name: repo['name'], id: repo['id'] }
       return data
     } else {
-      let datapackage = _tempEntries[0]['object']['text']
-      datapackage = JSON.parse(datapackage)
+      const datapackage = await getRawDataPackage(repo.name)
 
       if (Object.keys(datapackage).length == 0) {
         let data = { name: repo['name'], id: repo['id'] }
@@ -69,7 +62,6 @@ export const processRepo = (repo) => {
       }
     }
   } catch (error) {
-    console.log(error)
     return {}
   }
 }
@@ -87,6 +79,17 @@ export const repoHasResource = (repo) => {
 
 export function objectIsEmpty(obj) {
   return Object.keys(obj).length == 0
+}
+
+async function getRawDataPackage(repoName) {
+  const link = `https://raw.githubusercontent.com/gift-data/${repoName}/main/datapackage.json`
+  try {
+    const { data } = await axios.get(link)
+    return data
+  } catch (error) {
+    return {}
+  }
+
 }
 
 export function getRepoNames(data) {

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -37,7 +37,7 @@ export default function DashBoard({ datasets }) {
   )
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const apolloClient = initializeApollo()
 
   await apolloClient.query({
@@ -50,7 +50,8 @@ export async function getServerSideProps() {
   return {
     props: {
       initialApolloState: apolloClient.cache.extract(),
-      datasets
+      datasets,
+      revalidate: 30
     }
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -91,7 +91,7 @@ export default function Home({datasets}) {
   )
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const apolloClient = initializeApollo()
 
   await apolloClient.query({
@@ -109,6 +109,7 @@ export async function getServerSideProps() {
     props: {
       initialApolloState: apolloClient.cache.extract(),
       datasets,
+      revalidate: 60
     },
   }
 }


### PR DESCRIPTION
This PR fixes #172 

The solution here does the following:
* We refactor portal to always load a datapackage from its raw URL. 
* We change home and single dataset pages to use `incremental static generation` (ISG). 

Using ISG fixes the slow loading in the portal home page--when it is loading a raw datapackage over the network. This means that when updates are made via the admin dashboard, we have to wait for approximately 60 seconds before the changes are shown on the home page. 


See this article about [Incremental static regeneration](https://blog.logrocket.com/incremental-static-regeneration-with-next-js/)