### PR TITLE
[Publisher][s]: Update publisher version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "frictionless.js": "^0.13.4",
     "fuse.js": "^6.4.3",
     "giftless-client": "git+https://github.com/datopian/giftless-client-js.git",
-    "giftpub": "git+https://github.com/datopian/gift-publisher#ab06a9ac343866594b9bf6963101ddba9363fd44",
+    "giftpub": "git+https://github.com/datopian/gift-publisher#d5068fac37d3e32a51da8a774389365e268abfa6",
     "graphql": "^15.5.0",
     "graphql-request": "^3.4.0",
     "gray-matter": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8746,9 +8746,9 @@ getpass@^0.1.1:
   dependencies:
     axios "^0.21.1"
 
-"giftpub@git+https://github.com/datopian/gift-publisher#ab06a9ac343866594b9bf6963101ddba9363fd44":
-  version "0.2.9"
-  resolved "git+https://github.com/datopian/gift-publisher#ab06a9ac343866594b9bf6963101ddba9363fd44"
+"giftpub@git+https://github.com/datopian/gift-publisher#d5068fac37d3e32a51da8a774389365e268abfa6":
+  version "0.3.0"
+  resolved "git+https://github.com/datopian/gift-publisher#d5068fac37d3e32a51da8a774389365e268abfa6"
   dependencies:
     "@material-ui/core" "^4.11.2"
     axios "^0.21.1"


### PR DESCRIPTION
This PR updates gift publisher to the latest version (**Done** https://github.com/datopian/gift-publisher/pull/84) with support for file linking via URL. 